### PR TITLE
Remove unnecessary code

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ If you have any trouble with the installation, see [the troubleshooting guide](/
 ```python
 from blockstack_profiles import (
   sign_token, wrap_token, sign_token_records,
-  validate_token_record, get_profile_from_tokens,
-  make_zone_file_for_hosted_data,
-  resolve_zone_file_to_profile
+  validate_token_record, get_profile_from_tokens
 )
 ```
 
@@ -69,22 +67,4 @@ profile = get_profile_from_tokens(profile_tokens, "02f1fd79dcd51bd017f71546ddc0f
   "name": "Naval Ravikant", 
   "birthDate": "1980-01-01"
 }
-```
-
-### Creating Zone Files
-
-```python
-zone_file = make_zone_file_for_hosted_data("naval.id", "https://mq9.s3.amazonaws.com/naval.id/profile.json")
-```
-
-```
-$ORIGIN naval.id
-$TTL 3600
-@ IN URI "https://mq9.s3.amazonaws.com/naval.id/profile.json"
-```
-
-### Resolving Zone Files to Profiles
-
-```python
-profile = resolve_zone_file_to_profile(zone_file)
 ```

--- a/blockstack_profiles/__init__.py
+++ b/blockstack_profiles/__init__.py
@@ -7,10 +7,8 @@ from token_verifying import (
 )
 
 from zone_file_format import (
-    make_zone_file_for_hosted_data,
     get_token_file_url_from_zone_file,
-    zone_file_has_a_valid_uri_record,
-    resolve_zone_file_to_profile
+    zone_file_has_a_valid_uri_record
 )
 
 from legacy_format import (

--- a/blockstack_profiles/zone_file_format.py
+++ b/blockstack_profiles/zone_file_format.py
@@ -6,23 +6,6 @@ from .legacy_format import is_profile_in_legacy_format
 from .token_verifying import get_profile_from_tokens
 
 
-def make_zone_file_for_hosted_data(origin, token_file_url, ttl=3600):
-    if "://" not in token_file_url:
-        raise ValueError("Invalid token file URL")
-    json_zone_file = {
-        "$ttl": ttl,
-        "$origin": origin,
-        "uri": [{
-            "name": "_http._tcp",
-            "priority": 10,
-            "weight": 1,
-            "target": token_file_url
-        }]
-    }
-    zone_file = make_zone_file(json_zone_file)
-    return zone_file
-
-
 def get_token_file_url_from_zone_file(zone_file):
     token_file_url = None
 
@@ -47,21 +30,3 @@ def get_token_file_url_from_zone_file(zone_file):
 def zone_file_has_a_valid_uri_record(data):
     return get_token_file_url_from_zone_file(data) is not None
 
-
-def resolve_zone_file_to_profile(zone_file, address_or_public_key):
-    if is_profile_in_legacy_format(zone_file):
-        return zone_file
-
-    token_file_url = get_token_file_url_from_zone_file(zone_file)
-
-    try:
-        r = requests.get(token_file_url)
-    except:
-        return None
-
-    try:
-        profile_token_records = json.loads(r.text)
-    except ValueError:
-        return None
-    
-    return get_profile_from_tokens(profile_token_records, address_or_public_key)

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -6,12 +6,10 @@ from keylib import ECPrivateKey, ECPublicKey
 from blockstack_profiles import (
     sign_token, wrap_token, sign_token_records,
     verify_token, verify_token_record, get_profile_from_tokens,
-    make_zone_file_for_hosted_data,
     get_person_from_legacy_format,
     convert_profile_to_legacy_format,
     get_token_file_url_from_zone_file,
-    zone_file_has_a_valid_uri_record,
-    resolve_zone_file_to_profile
+    zone_file_has_a_valid_uri_record
 )
 from test_data import reference_profiles
 
@@ -92,16 +90,6 @@ _http._tcp URI 10 1 \"https://blockstack.s3.amazonaws.com/ryan_apr20.id\""""
     def tearDown(self):
         pass
 
-    def test_zone_file_creation(self):
-        origin = "naval.id"
-        token_file_url = "https://mq9.s3.amazonaws.com/naval.id/profile.json"
-        zone_file = make_zone_file_for_hosted_data(origin, token_file_url)
-        # print zone_file
-        self.assertTrue(isinstance(zone_file, (unicode, str)))
-        self.assertTrue("$ORIGIN" in zone_file)
-        self.assertTrue("$TTL" in zone_file)
-        self.assertTrue("_http._tcp URI" in zone_file)
-
     def test_token_file_url_recovery_from_zone_file(self):
         token_file_url = get_token_file_url_from_zone_file(self.zone_file)
         self.assertEqual(token_file_url, "https://mq9.s3.amazonaws.com/naval.id/profile.json")
@@ -109,10 +97,6 @@ _http._tcp URI 10 1 \"https://blockstack.s3.amazonaws.com/ryan_apr20.id\""""
     def test_zone_file_has_a_valid_uri_record(self):
         is_valid = zone_file_has_a_valid_uri_record(self.zone_file)
         self.assertTrue(is_valid)
-
-    def test_resolve_zone_file_to_profile(self):
-        profile = resolve_zone_file_to_profile(self.zone_file_2, self.public_key_2)
-        self.assertTrue("name" in profile)
 
 
 class LegacyFormatTests(unittest.TestCase):


### PR DESCRIPTION
`blockstack-profiles` should not be responsible for constructing zonefiles or resolving them to data.
This should be the exclusive responsibility of the `blockstack-client` package, since
- `blockstack-client` is already responsible for constructing and manipulating zonefiles for
  storing things like immutable data and data public keys;
- the Blockstack-specific uses of the zonefile are implementation details that are subject to change, so we don't want external programs to assume anything about their contents;
- the protocol-specific URL construction, formatting, and resolution logic is already provided by
  the `blockstack-storage-drivers` package;
- `blockstack-client` already provides a unified interface for locating data via the `blockstack://` URL scheme.
